### PR TITLE
Filter shows on My Shows by "In Progress" or "Completed"

### DIFF
--- a/front-end/src/MyShows.css
+++ b/front-end/src/MyShows.css
@@ -24,7 +24,7 @@
     width: 20rem;
     border: none;
     padding: 0.5rem;
-    background: #F2F1F9;
+    background: #e6e6e6;
     display: block;
 }
 
@@ -36,9 +36,10 @@
 button {
     margin: 2em;
     border: none;
+    background: #e6e6e6;
     padding: 1em 2em 1em 2em;
 }
 
 .selected {
-    background-color: blue;
+    background: #acf39d;
 }

--- a/front-end/src/MyShows.css
+++ b/front-end/src/MyShows.css
@@ -38,3 +38,7 @@ button {
     border: none;
     padding: 1em 2em 1em 2em;
 }
+
+.selected {
+    background-color: blue;
+}

--- a/front-end/src/MyShows.js
+++ b/front-end/src/MyShows.js
@@ -18,9 +18,7 @@ const ShowGrid = (props) => {
       setShows([]);
     }
     else {
-      // Note: At the moment, we don't need any of the mocked data since we only really need the image here
-      // but it's being mocked with picsum for now.
-      filterShows(props.shows).map((show) => {
+      props.shows.map((show) => {
         promises.push(
           axios.get(`https://my.api.mockaroo.com/shows/${show.id}.json?key=`)
             .then((response) => {
@@ -58,7 +56,7 @@ const ShowGrid = (props) => {
 }
 
 // For now, a very simple + non-function search.
-// I'm thinking of using react-sync to show search results in a drop-down
+// I'm thinking of using react-select-async to show search results in a dropdown
 const Search = ({ input, onChange }) => {
   return (
     <div id="search-container">
@@ -72,8 +70,24 @@ const Search = ({ input, onChange }) => {
   )
 }
 
+// filterShows filters a list of shows with user information by their status (indicated by a boolean)
+// the status variable being passed into this function, however, is a string as to account for
+// the case where no show status filtering is being done
 const filterShows = (shows, status) => {
-  return !shows ? [] :shows.filter( (show) => show.status === status );
+  const isCompleted = status === "Completed";
+  if (!shows) {
+    return [];
+  }
+  else {
+    const filtered = shows.filter( (show) => {
+      if (status === "") {
+        return show;
+      }
+      return show.completed === isCompleted;
+    });
+    console.log(filtered)
+    return filtered;
+  }
 }
 
 const MyShows = (props) => {
@@ -105,6 +119,7 @@ const MyShows = (props) => {
   const onStatusChange = ( (buttonType) => {
     if (buttonType === "in progress") {
       inProgressSelected ? setStatus("") : setStatus("In Progress");
+      // This if statement logic ensures that the two status buttons are never on at the same time
       if (status !== "") {
         setCompletedSelected(false);
       }
@@ -140,7 +155,7 @@ const MyShows = (props) => {
             Completed
           </button>
         </div>
-        <ShowGrid shows={userData.shows} status={status} />
+        <ShowGrid shows={filterShows(userData.shows, status)} status={status} />
       </div>
       <Footer />
     </>

--- a/front-end/src/MyShows.js
+++ b/front-end/src/MyShows.js
@@ -20,7 +20,7 @@ const ShowGrid = (props) => {
     else {
       // Note: At the moment, we don't need any of the mocked data since we only really need the image here
       // but it's being mocked with picsum for now.
-      props.shows.map((show) => {
+      filterShows(props.shows).map((show) => {
         promises.push(
           axios.get(`https://my.api.mockaroo.com/shows/${show.id}.json?key=`)
             .then((response) => {
@@ -72,21 +72,16 @@ const Search = ({ input, onChange }) => {
   )
 }
 
-const Filters = () => {
-  return (
-    <>
-      <div id="filter-container">
-        <button> In Progress </button>
-        <button> Filter Shows </button>
-        <button> Completed </button>
-      </div>
-    </>
-  )
+const filterShows = (shows, status) => {
+  return !shows ? [] :shows.filter( (show) => show.status === status );
 }
 
 const MyShows = (props) => {
   const [userData, setUserData] = useState([]);
   const [input, setInput] = useState('');
+  const [status, setStatus] = useState('');
+  const [inProgressSelected, setInProgressSelected] = useState(false);
+  const [completedSelected, setCompletedSelected] = useState(false);
 
   useEffect(() => {
     axios(`https://my.api.mockaroo.com/tv_users/${props.id}.json?key=`)
@@ -103,9 +98,26 @@ const MyShows = (props) => {
       });
   }, [props.id]);
 
-  const updateInput = (input => {
+  const updateInput = ( (input) => {
     setInput(input)
-  })
+  });
+
+  const onStatusChange = ( (buttonType) => {
+    if (buttonType === "in progress") {
+      inProgressSelected ? setStatus("") : setStatus("In Progress");
+      if (status !== "") {
+        setCompletedSelected(false);
+      }
+      setInProgressSelected(!inProgressSelected);
+    }
+    else {
+      completedSelected ? setStatus("") : setStatus("Completed");
+      if (status !== "") {
+        setInProgressSelected(false);
+      }
+      setCompletedSelected(!completedSelected);
+    }
+  });
 
   return (
     <>
@@ -113,8 +125,22 @@ const MyShows = (props) => {
       <div id="container">
         <h3>{userData.username}'s Shows</h3>
         <Search input={input} onChange={updateInput} />
-        <Filters />
-        <ShowGrid shows={userData.shows} />
+        <div id="filter-container">
+          <button 
+            className={inProgressSelected ? "selected" : ""}
+            onClick={(e) => onStatusChange("in progress")}
+          >
+            In Progress 
+          </button>
+          <button> Filter Shows </button>
+          <button 
+            className={completedSelected ? "selected" : ""}
+            onClick={(e) => onStatusChange("completed")}
+          >
+            Completed
+          </button>
+        </div>
+        <ShowGrid shows={userData.shows} status={status} />
       </div>
       <Footer />
     </>

--- a/front-end/src/MyShows.js
+++ b/front-end/src/MyShows.js
@@ -55,7 +55,7 @@ const ShowGrid = (props) => {
   )
 }
 
-// For now, a very simple + non-function search.
+// For now, a very simple + non-functional search.
 // I'm thinking of using react-select-async to show search results in a dropdown
 const Search = ({ input, onChange }) => {
   return (


### PR DESCRIPTION
resolves #32 

I've decided to rename the "Watched" category to "Completed" so as to avoid confusion with simply watching a single episode of a show (as compared to completing a show in its entirety, which is what this status is meant for). If people disagree with this change, it'll be a quick fix.

Something else worth noting is that when we actually create our backend API, if we were to replace the boolean `completed` field in our (right now, mock) schema with a String field to indicate status, it'd both simplify the filtering logic _and_ be a bit more adaptable if we decide to support more watch statuses (such as "Planning") in the future.