### PR TITLE
Add Trakt API setup guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,8 +70,8 @@ You can now use ``client_id`` and ``client_secret`` for making Trakt API calls. 
 3. To create Oauth, please follow these instructions [here](https://github.com/xbgmsharp/trakt#usage). Note: for Sprint 2, Oauth will not be needed. 
 4. In your .env file, add the following line: 
 
-> API_TRAKT_KEY=your_client_id
+> API_KEY_TRAKT=your_client_id
 
 For example, if your client id is 123456, the file would read:
 
-> API_TRAKT_KEY=123456
+> API_KEY_TRAKT=123456

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,15 +63,11 @@ To use Trakt API, you need to register for an account and create a Trakt App.
 2. Create a new Trakt API app [here](https://trakt.tv/oauth/applications/new) to have 
 your own ``client_id`` and ``client_secret``. <br>
 For ``Name``, enter your project name (e.g. *TV Tracker*). <br>
-For ``Description`` enter description for the project (e.g. *App allows to retrieve 
-information about trending shows and store it*). <br>
+For ``Description`` enter description for the project (e.g. *App allows to retrieve information about trending shows and store it*). <br>
 For ``Redirect uri``, enter `urn:ietf:wg:oauth:2.0:oob`. <br>
 Leave the rest empty and click on ``SAVE APP``. <br>
-You can now use ``client_id`` and ``client_secret`` for making Trakt API calls. More 
-information about Trakt API required headers is available [here](https://trakt.docs.
-apiary.io/#introduction/required-headers). 
-3. To create Oauth, please follow these instructions [here](https://github.com/
-xbgmsharp/trakt#usage). Note: for Sprint 2, Oauth will not be needed. 
+You can now use ``client_id`` and ``client_secret`` for making Trakt API calls. More information about Trakt API required headers is available [here](https://trakt.docs.apiary.io/#introduction/required-headers). 
+3. To create Oauth, please follow these instructions [here](https://github.com/xbgmsharp/trakt#usage). Note: for Sprint 2, Oauth will not be needed. 
 
 
  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,13 @@ For ``Redirect uri``, enter `urn:ietf:wg:oauth:2.0:oob`. <br>
 Leave the rest empty and click on ``SAVE APP``. <br>
 You can now use ``client_id`` and ``client_secret`` for making Trakt API calls. More information about Trakt API required headers is available [here](https://trakt.docs.apiary.io/#introduction/required-headers). 
 3. To create Oauth, please follow these instructions [here](https://github.com/xbgmsharp/trakt#usage). Note: for Sprint 2, Oauth will not be needed. 
+4. In your .env file, add the following line: 
+
+> API_TRAKT_KEY=your_client_id
+
+For example, if your client id is 123456, the file would read:
+
+> API_TRAKT_KEY=123456
 
 
  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,12 +75,3 @@ You can now use ``client_id`` and ``client_secret`` for making Trakt API calls. 
 For example, if your client id is 123456, the file would read:
 
 > API_TRAKT_KEY=123456
-
-
- 
-
-
-
-
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,24 @@ For the front-end, navigate to the front-end folder and run `npm start` in the c
 
 To use Trakt API, you need to register for an account and create a Trakt App. 
 1. Register for an account [here](https://login.apiary.io/register).
-2. Create a new Trakt API app [here](https://trakt.tv/oauth/applications/new) to have your own ``client_id`` and ``client_secret``, https://trakt.tv/oauth/applications.<br>
-You only need to fill up the ``Name`` with a ``Description`` and ``Redirect uri`` to `urn:ietf:wg:oauth:2.0:oob`, leave the rest empty and click on ``SAVE APP``.
-You can now use ``client_id`` and ``client_secret`` for making Trakt API calls. 
-3. To create Oauth, please follow these instructions [here](https://github.com/xbgmsharp/trakt#usage). Note: for Sprint 2, Oauth will not be needed. 
+2. Create a new Trakt API app [here](https://trakt.tv/oauth/applications/new) to have 
+your own ``client_id`` and ``client_secret``. <br>
+For ``Name``, enter your project name (e.g. *TV Tracker*). <br>
+For ``Description`` enter description for the project (e.g. *App allows to retrieve 
+information about trending shows and store it*). <br>
+For ``Redirect uri``, enter `urn:ietf:wg:oauth:2.0:oob`. <br>
+Leave the rest empty and click on ``SAVE APP``. <br>
+You can now use ``client_id`` and ``client_secret`` for making Trakt API calls. More 
+information about Trakt API required headers is available [here](https://trakt.docs.
+apiary.io/#introduction/required-headers). 
+3. To create Oauth, please follow these instructions [here](https://github.com/
+xbgmsharp/trakt#usage). Note: for Sprint 2, Oauth will not be needed. 
+
+
+ 
+
+
+
+
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,4 +56,11 @@ For the front-end, navigate to the front-end folder and run `npm start` in the c
 
 ## Building and Testing
 
-TBD.
+### Trakt API
+
+To use Trakt API, you need to register for an account and create a Trakt App. 
+1. Register for an account [here](https://login.apiary.io/register).
+2. Create a new Trakt API app [here](https://trakt.tv/oauth/applications/new) to have your own ``client_id`` and ``client_secret``, https://trakt.tv/oauth/applications.<br>
+You only need to fill up the ``Name`` with a ``Description`` and ``Redirect uri`` to `urn:ietf:wg:oauth:2.0:oob`, leave the rest empty and click on ``SAVE APP``.
+You can now use ``client_id`` and ``client_secret`` for making Trakt API calls. 
+3. To create Oauth, please follow these instructions [here](https://github.com/xbgmsharp/trakt#usage). Note: for Sprint 2, Oauth will not be needed. 

--- a/README.md
+++ b/README.md
@@ -96,10 +96,8 @@ For ``Description`` enter description for the project (e.g. *App allows to retri
 For ``Redirect uri``, enter `urn:ietf:wg:oauth:2.0:oob`. <br>
 Leave the rest empty and click on ``SAVE APP``. <br>
 You can now use ``client_id`` and ``client_secret`` for making Trakt API calls. More 
-information about Trakt API required headers is available [here](https://trakt.docs.
-apiary.io/#introduction/required-headers). 
-3. To create Oauth, please follow these instructions [here](https://github.com/
-xbgmsharp/trakt#usage). Note: for Sprint 2, Oauth will not be needed. 
+information about Trakt API required headers is available [here](https://trakt.docs.apiary.io/#introduction/required-headers). 
+3. To create Oauth, please follow these instructions [here](https://github.com/xbgmsharp/trakt#usage). Note: for Sprint 2, Oauth will not be needed. 
 
 
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To start the back end of the project, navigate to the back-end folder and run th
 
 In back-end, create a file named '.env' with the following contents:
 
-> API_MOCKAROO_KEY=[your API key]
+> API_KEY_MOCKAROO=[your API key]
 
 Replace [your API key] with your actual API key. Save the file and close it.
 
@@ -100,8 +100,8 @@ information about Trakt API required headers is available [here](https://trakt.d
 3. To create Oauth, please follow these instructions [here](https://github.com/xbgmsharp/trakt#usage). Note: for Sprint 2, Oauth will not be needed. 
 4. In your .env file, add the following line: 
 
-> API_TRAKT_KEY=your_client_id
+> API_KEY_TRAKT=your_client_id
 
 For example, if your client id is 123456, the file would read:
 
-> API_TRAKT_KEY=123456
+> API_KEY_TRAKT=123456

--- a/README.md
+++ b/README.md
@@ -85,13 +85,24 @@ Then, in back-end, run:
 
 > npx nodemon
 
-
 ### Trakt API Setup
 
 To use Trakt API, you need to register for an account and create a Trakt App. 
 1. Register for an account [here](https://login.apiary.io/register).
-2. Create a new Trakt API app [here](https://trakt.tv/oauth/applications/new) to have your own ``client_id`` and ``client_secret``. <br>
-You only need to fill up the ``Name`` with a ``Description`` and ``Redirect uri`` to `urn:ietf:wg:oauth:2.0:oob`, leave the rest empty and click on ``SAVE APP``. 
-You can now use ``client_id`` and ``client_secret`` for making Trakt API calls. 
+2. Create a new Trakt API app [here](https://trakt.tv/oauth/applications/new) to have 
+your own ``client_id`` and ``client_secret``. <br>
+For ``Name``, enter your project name (e.g. *TV Tracker*). <br>
+For ``Description`` enter description for the project (e.g. *App allows to retrieve information about trending shows and store it*). <br>
+For ``Redirect uri``, enter `urn:ietf:wg:oauth:2.0:oob`. <br>
+Leave the rest empty and click on ``SAVE APP``. <br>
+You can now use ``client_id`` and ``client_secret`` for making Trakt API calls. More 
+information about Trakt API required headers is available [here](https://trakt.docs.
+apiary.io/#introduction/required-headers). 
 3. To create Oauth, please follow these instructions [here](https://github.com/
 xbgmsharp/trakt#usage). Note: for Sprint 2, Oauth will not be needed. 
+
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -105,8 +105,3 @@ information about Trakt API required headers is available [here](https://trakt.d
 For example, if your client id is 123456, the file would read:
 
 > API_TRAKT_KEY=123456
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ You can take a look at the original project proposal [here](https://github.com/a
 
 Fork (if intending to make changes) or clone this repository.
 
+### Building 
+
 To start the front end of the project, navigate to the front-end folder and run the following commands in the command line:
 
 > npm install
@@ -82,3 +84,14 @@ Replace [your API key] with your actual API key. Save the file and close it.
 Then, in back-end, run:
 
 > npx nodemon
+
+
+### Trakt API Setup
+
+To use Trakt API, you need to register for an account and create a Trakt App. 
+1. Register for an account [here](https://login.apiary.io/register).
+2. Create a new Trakt API app [here](https://trakt.tv/oauth/applications/new) to have your own ``client_id`` and ``client_secret``. <br>
+You only need to fill up the ``Name`` with a ``Description`` and ``Redirect uri`` to `urn:ietf:wg:oauth:2.0:oob`, leave the rest empty and click on ``SAVE APP``. 
+You can now use ``client_id`` and ``client_secret`` for making Trakt API calls. 
+3. To create Oauth, please follow these instructions [here](https://github.com/
+xbgmsharp/trakt#usage). Note: for Sprint 2, Oauth will not be needed. 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To start the back end of the project, navigate to the back-end folder and run th
 
 In back-end, create a file named '.env' with the following contents:
 
-> MOCKAROO_KEY=[your API key]
+> API_MOCKAROO_KEY=[your API key]
 
 Replace [your API key] with your actual API key. Save the file and close it.
 
@@ -98,7 +98,13 @@ Leave the rest empty and click on ``SAVE APP``. <br>
 You can now use ``client_id`` and ``client_secret`` for making Trakt API calls. More 
 information about Trakt API required headers is available [here](https://trakt.docs.apiary.io/#introduction/required-headers). 
 3. To create Oauth, please follow these instructions [here](https://github.com/xbgmsharp/trakt#usage). Note: for Sprint 2, Oauth will not be needed. 
+4. In your .env file, add the following line: 
 
+> API_TRAKT_KEY=your_client_id
+
+For example, if your client id is 123456, the file would read:
+
+> API_TRAKT_KEY=123456
 
 
 


### PR DESCRIPTION
I have changed MOCKAROO_KEY in the . env file for the back-end folder to API_MOCKAROO_KEY since if there are several values in the . env file, it seems that names have to be consistent (have a common prefix)
otherwise, Trakt API request is not going through; example from Prof's folder also has consistent naming: https://github.com/bloombar/express-js-starter-app/blob/master/.env.example