### PR TITLE
Replace Mockaroo calls with calls to our API

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -6,6 +6,15 @@ require('dotenv').config()
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
 app.use(morgan("dev")) // dev is a concise color-coded default style for morgan
+app.use((req, res, next) => {
+	res.header('Access-Control-Allow-Origin', 'http://localhost:3000')
+	res.header('Access-Control-Allow-Methods', 'GET, POST, PATCH')
+	res.header(
+		'Access-Control-Allow-Headers',
+		'Origin, X-Requested-With, Content-Type, Accept'
+	)
+	next()
+})
 
 app.get('/tv_users', (req, res, next) => {
     axios.get(`https://my.api.mockaroo.com/tv_users.json?key=${process.env.MOCKAROO_KEY}`)

--- a/front-end/src/IndividualShow.js
+++ b/front-end/src/IndividualShow.js
@@ -109,14 +109,14 @@ const IndividualShow = ({ id }) => {
     // Fetch show meta-information from the API
     axios
       .get(
-        `https://my.api.mockaroo.com/shows/${id}.json?key=${process.env.REACT_APP_MOCKAROO_KEY}`
+        `http://localhost:3000/shows/${id}`
       )
       .then((response) => {
         setShow(response.data)
       })
       .catch((err) => {
         console.log(
-          "We likely reached Mockaroo's request limit, or you did not insert your API key in .env."
+          "Error: could not make the request."
         )
         console.log(err)
         setShow(mockShowAPI[id])
@@ -160,7 +160,7 @@ const IndividualShow = ({ id }) => {
       }
       axios
         .patch(
-          `https://my.api.mockaroo.com/tv_users/${loggedInUser.id}.json?key=${process.env.REACT_APP_MOCKAROO_KEY}&__method=PATCH`,
+          `http://localhost:3000/tv_users/${loggedInUser.id}`,
           patchUser
         )
         .then((response) => {
@@ -168,7 +168,7 @@ const IndividualShow = ({ id }) => {
         })
         .catch((err) => {
           console.log(
-            "We likely reached Mockaroo's request limit, or you did not insert your API key in .env."
+            "Error: could not make the request."
           )
           console.log(err)
           setLoggedInUser(patchUser)

--- a/front-end/src/IndividualShow.js
+++ b/front-end/src/IndividualShow.js
@@ -109,7 +109,7 @@ const IndividualShow = ({ id }) => {
     // Fetch show meta-information from the API
     axios
       .get(
-        `http://localhost:3000/shows/${id}`
+        `http://localhost:4000/shows/${id}`
       )
       .then((response) => {
         setShow(response.data)
@@ -160,7 +160,7 @@ const IndividualShow = ({ id }) => {
       }
       axios
         .patch(
-          `http://localhost:3000/tv_users/${loggedInUser.id}`,
+          `http://localhost:4000/tv_users/${loggedInUser.id}`,
           patchUser
         )
         .then((response) => {

--- a/front-end/src/Login.js
+++ b/front-end/src/Login.js
@@ -19,7 +19,7 @@ function Login() {
     // Actual login handling will go here; for now, we'll simply get a user
     // from our Mockaroo API. User id is hardcoded for now.
     axios(
-      `https://my.api.mockaroo.com/tv_users/1.json?key=${process.env.REACT_APP_MOCKAROO_KEY}`
+      `http://localhost:3000/tv_users/1`
     )
       .then((response) => {
         setLoggedInUser(response.data)
@@ -30,7 +30,7 @@ function Login() {
         // It'd be good to add some error handling here later, if someone tries to
         // access a non-existent user
         console.log(
-          "We likely reached Mockaroo's request limit, or you did not insert your API key in .env."
+          "Error: could not make the request."
         )
         console.log(err)
         const mockUser = createMockUser(1)

--- a/front-end/src/Login.js
+++ b/front-end/src/Login.js
@@ -19,7 +19,7 @@ function Login() {
     // Actual login handling will go here; for now, we'll simply get a user
     // from our Mockaroo API. User id is hardcoded for now.
     axios(
-      `http://localhost:3000/tv_users/1`
+      `http://localhost:4000/tv_users/1`
     )
       .then((response) => {
         setLoggedInUser(response.data)

--- a/front-end/src/MyShows.js
+++ b/front-end/src/MyShows.js
@@ -33,14 +33,14 @@ const ShowGrid = (props) => {
         promises.push(
           axios
             .get(
-              `https://my.api.mockaroo.com/shows/${show.id}.json?key=${process.env.REACT_APP_MOCKAROO_KEY}`
+              `http://localhost:3000/shows/${show.id}`
             )
             .then((response) => {
               showInfo.push(response.data)
             })
             .catch((err) => {
               console.log(
-                "We likely reached Mockaroo's request limit, or you did not insert your API key in .env."
+                "Error: could not make the request."
               )
               console.log(err)
               showInfo.push(mockShowAPI[show.id])
@@ -126,7 +126,7 @@ const MyShows = (props) => {
 
   useEffect(() => {
     axios(
-      `https://my.api.mockaroo.com/tv_users/${props.id}.json?key=${process.env.REACT_APP_MOCKAROO_KEY}`
+      `http://localhost:3000/tv_users/${props.id}`
     )
       .then((response) => {
         setUserData(response.data)
@@ -136,7 +136,7 @@ const MyShows = (props) => {
         // It'd be good to add some error handling here later, if someone tries to
         // access a non-existent user
         console.log(
-          "We likely reached Mockaroo's request limit, or you did not insert your API key in .env."
+          "Error: could not make the request."
         )
         console.log(err)
         const mockUser = createMockUser(props.id)
@@ -178,14 +178,14 @@ const MyShows = (props) => {
   const loadOptions = (input) => {
     return axios
       .get(
-        `https://my.api.mockaroo.com/shows.json?key=${process.env.REACT_APP_MOCKAROO_KEY}`
+        `http://localhost:3000/shows`
       )
       .then((response) => {
         return searchShows(input, response.data)
       })
       .catch((err) => {
         console.log(
-          "We likely reached Mockaroo's request limit, or you did not insert your API key in .env."
+          "Error: could not make the request."
         )
         console.log(err)
         return searchShows(input, mockAllShows)

--- a/front-end/src/MyShows.js
+++ b/front-end/src/MyShows.js
@@ -33,7 +33,7 @@ const ShowGrid = (props) => {
         promises.push(
           axios
             .get(
-              `http://localhost:3000/shows/${show.id}`
+              `http://localhost:4000/shows/${show.id}`
             )
             .then((response) => {
               showInfo.push(response.data)
@@ -126,7 +126,7 @@ const MyShows = (props) => {
 
   useEffect(() => {
     axios(
-      `http://localhost:3000/tv_users/${props.id}`
+      `http://localhost:4000/tv_users/${props.id}`
     )
       .then((response) => {
         setUserData(response.data)
@@ -178,7 +178,7 @@ const MyShows = (props) => {
   const loadOptions = (input) => {
     return axios
       .get(
-        `http://localhost:3000/shows`
+        `http://localhost:4000/shows`
       )
       .then((response) => {
         return searchShows(input, response.data)

--- a/front-end/src/Profile.js
+++ b/front-end/src/Profile.js
@@ -74,7 +74,7 @@ const SettingsForm = (props) => {
     }
     axios
       .patch(
-        `http://localhost:3000/tv_users/${props.data.id}`, newData
+        `http://localhost:4000/tv_users/${props.data.id}`, newData
       )
       .then((response) => {
         console.log(response)
@@ -193,7 +193,7 @@ const ProfileContents = ({ data, updateUserData }) => {
         promises.push(
           axios
             .get(
-              `http://localhost:3000/shows/${show.id}`
+              `http://localhost:4000/shows/${show.id}`
             )
             .then((response) => {
               showInfo.push(response.data)
@@ -280,7 +280,7 @@ const Profile = (props) => {
 
   useEffect(() => {
     axios(
-      `http://localhost:3000/tv_users/${props.id}`
+      `http://localhost:4000/tv_users/${props.id}`
     )
       .then((response) => {
         setUserData(response.data)

--- a/front-end/src/Profile.js
+++ b/front-end/src/Profile.js
@@ -74,8 +74,7 @@ const SettingsForm = (props) => {
     }
     axios
       .patch(
-        `https://my.api.mockaroo.com/tv_users/${props.data.id}.json?key=${process.env.REACT_APP_MOCKAROO_KEY}&__method=PATCH`,
-        newData
+        `http://localhost:3000/tv_users/${props.data.id}`, newData
       )
       .then((response) => {
         console.log(response)
@@ -84,7 +83,7 @@ const SettingsForm = (props) => {
       })
       .catch((err) => {
         console.log(
-          "We likely reached Mockaroo's request limit, or you did not insert your API key in .env."
+          "Error: could not make the request."
         )
         console.log(err)
         props.updateUserData(mockUserUpdate(props.data.id, newData))
@@ -194,14 +193,14 @@ const ProfileContents = ({ data, updateUserData }) => {
         promises.push(
           axios
             .get(
-              `https://my.api.mockaroo.com/shows/${show.id}.json?key=${process.env.REACT_APP_MOCKAROO_KEY}`
+              `http://localhost:3000/shows/${show.id}`
             )
             .then((response) => {
               showInfo.push(response.data)
             })
             .catch((err) => {
               console.log(
-                "We likely reached Mockaroo's request limit, or you did not insert your API key in .env."
+                "Error: could not make the request."
               )
               console.log(err)
               showInfo.push(mockShowAPI[show.id])
@@ -281,7 +280,7 @@ const Profile = (props) => {
 
   useEffect(() => {
     axios(
-      `https://my.api.mockaroo.com/tv_users/${props.id}.json?key=${process.env.REACT_APP_MOCKAROO_KEY}`
+      `http://localhost:3000/tv_users/${props.id}`
     )
       .then((response) => {
         setUserData(response.data)
@@ -291,7 +290,7 @@ const Profile = (props) => {
         // It'd be good to add some error handling here later, if someone tries to
         // access a non-existent user
         console.log(
-          "We likely reached Mockaroo's request limit, or you did not insert your API key in .env."
+          "Error: could not make the request."
         )
         console.log(err)
         const mockUser = createMockUser(props.id)

--- a/front-end/src/Signup.js
+++ b/front-end/src/Signup.js
@@ -30,7 +30,7 @@ function Signup() {
 
     axios
       .post(
-        `https://my.api.mockaroo.com/tv_users.json?key=${process.env.REACT_APP_MOCKAROO_KEY}&__method=POST`,
+        `http://localhost:3000/tv_users/`,
         newUser
       )
       .then((response) => {
@@ -38,7 +38,7 @@ function Signup() {
       })
       .catch((err) => {
         console.log(
-          "We likely reached Mockaroo's request limit, or you did not insert your API key in .env."
+          "Error: could not make the request."
         )
         history.push('/profile/1')
       })

--- a/front-end/src/Signup.js
+++ b/front-end/src/Signup.js
@@ -30,7 +30,7 @@ function Signup() {
 
     axios
       .post(
-        `http://localhost:3000/tv_users/`,
+        `http://localhost:4000/tv_users/`,
         newUser
       )
       .then((response) => {


### PR DESCRIPTION
#115 replaces calls to Mockaroo with calls to our API. I also replaced the error message with a more generic one.